### PR TITLE
Fix: Match the targetPort on the deployment

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ type: application
 appVersion: v1.28.0
 description: The reference implementation for a Matrix.org chat server
 name: synapse
-version: 0.7.28
+version: 0.7.29
 keywords:
   - synapse
   - chat

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -17,8 +17,8 @@ spec:
       protocol: TCP
       name: worker-tcp
     - port: 9093
-      targetPort: worker-http
+      targetPort: worker-web
       protocol: TCP
-      name: worker-http
+      name: worker-web
   selector:
     {{- include "synapse.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
After a short debugging session why I had to hardcode the pod IP of the synapse deployment I found that the names dont match:

https://github.com/halkeye-helm-charts/synapse/blob/master/templates/deployment.yaml#L119
vs
https://github.com/halkeye-helm-charts/synapse/blob/master/templates/service.yaml#L20

I would suggest patching it in the service because this does not require a redeployment.