### PR TITLE
Mounting federation sender/reader data directories to main PVC

### DIFF
--- a/templates/deployment_federation_reader.yaml
+++ b/templates/deployment_federation_reader.yaml
@@ -107,7 +107,12 @@ spec:
     {{- end }}
       volumes:
         - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "synapse.fullname" .) }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         - name: config
           secret:
             secretName: {{ include "synapse.fullname" . }}

--- a/templates/deployment_federation_sender.yaml
+++ b/templates/deployment_federation_sender.yaml
@@ -107,7 +107,12 @@ spec:
     {{- end }}
       volumes:
         - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "synapse.fullname" .) }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
         - name: config
           secret:
             secretName: {{ include "synapse.fullname" . }}


### PR DESCRIPTION
I've created a pull request to address an issue with the federation reader/sender deployment failing as mentioned in [#5](https://github.com/halkeye-helm-charts/synapse/issues/5#issue-895018539). The problem was caused by the federation sender and reader deployments using an EmptyDir for their data directories, resulting in failure to access the signing key from the main app deployment's data directory (mounted to the main PVC). To fix this, I modified the chart to mount the federation sender and reader data directories to the main PVC.